### PR TITLE
Improvements to case study pages

### DIFF
--- a/app/_case_studies/2019-03-14-ipsum.md
+++ b/app/_case_studies/2019-03-14-ipsum.md
@@ -5,6 +5,9 @@ theme: dark
 
 title: Ipsum dolor sit amet
 client: Major
+hero:
+  bg_color: purple
+  bg_image:
 images:
   full: /assets/graphics/content/climatescope2018-hero.jpg
   small:

--- a/app/_case_studies/2019-03-14-ipsum.md
+++ b/app/_case_studies/2019-03-14-ipsum.md
@@ -1,6 +1,7 @@
 ---
 layout: case-study
 permalink: case-studies/ipsum/
+theme: dark
 
 title: Ipsum dolor sit amet
 client: Major

--- a/app/_case_studies/2019-03-14-ipsum.md
+++ b/app/_case_studies/2019-03-14-ipsum.md
@@ -39,15 +39,17 @@ s_summary:
 
 # Metrics section
 s_metrics:
-  - title: Non ullamcorper
-    description: Etiam pellentesque faucibus nunc, id ullamcorper nisi varius sit amet.
-    value: 3.14
-  - title: Purus gravida
-    description: Duis pharetra ipsum non egestas interdum
-    value: 9%
-  - title: Mauris sed orci
-    description: Interdum et malesuada fames ac ante ipsum primis in faucibus. Duis feugiat sed erat a pretium.
-    value: 5 / 7
+  class: some-class
+  items:
+    - title: Non ullamcorper
+      description: Etiam pellentesque faucibus nunc, id ullamcorper nisi varius sit amet.
+      value: 3.14
+    - title: Purus gravida
+      description: Duis pharetra ipsum non egestas interdum
+      value: 9%
+    - title: Mauris sed orci
+      description: Interdum et malesuada fames ac ante ipsum primis in faucibus. Duis feugiat sed erat a pretium.
+      value: 5 / 7
 
 # Featured quote section
 s_feature_quote:

--- a/app/_case_studies/2019-03-14-ipsum.md
+++ b/app/_case_studies/2019-03-14-ipsum.md
@@ -72,6 +72,7 @@ s_content:
   - type: section-tl
     class:
     bgcolor:
+    color:
     title: Nunc et ultrices neque
     content: |
       Integer consequat tellus urna, non aliquet tellus tempor id.

--- a/app/_case_studies/2019-03-15-lorem.md
+++ b/app/_case_studies/2019-03-15-lorem.md
@@ -35,15 +35,17 @@ s_summary:
 
 # Metrics section
 s_metrics:
-  - title: Non ullamcorper
-    description: Etiam pellentesque faucibus nunc, id ullamcorper nisi varius sit amet.
-    value: 3.14
-  - title: Purus gravida
-    description: Duis pharetra ipsum non egestas interdum
-    value: 9%
-  - title: Mauris sed orci
-    description: Interdum et malesuada fames ac ante ipsum primis in faucibus. Duis feugiat sed erat a pretium.
-    value: 5 / 7
+  class:
+  items:
+    - title: Non ullamcorper
+      description: Etiam pellentesque faucibus nunc, id ullamcorper nisi varius sit amet.
+      value: 3.14
+    - title: Purus gravida
+      description: Duis pharetra ipsum non egestas interdum
+      value: 9%
+    - title: Mauris sed orci
+      description: Interdum et malesuada fames ac ante ipsum primis in faucibus. Duis feugiat sed erat a pretium.
+      value: 5 / 7
 
 # Featured quote section
 s_feature_quote:

--- a/app/_case_studies/2019-03-16-model.md
+++ b/app/_case_studies/2019-03-16-model.md
@@ -35,12 +35,14 @@ s_summary:
 
 # Metrics section
 s_metrics:
-  - title: Metric title
-    description: Metric subtitle/description that can have two lines
-    value: 999
-  - title: Metric title 2
-    description: Metric subtitle/description that can have two lines 2
-    value: 9%
+  class:
+  items:
+    - title: Metric title
+      description: Metric subtitle/description that can have two lines
+      value: 999
+    - title: Metric title 2
+      description: Metric subtitle/description that can have two lines 2
+      value: 9%
 
 # Featured quote section
 s_feature_quote:

--- a/app/_includes/case-studies/content-section.html
+++ b/app/_includes/case-studies/content-section.html
@@ -16,7 +16,11 @@
   {% assign bgklass='sec-background-white' %}
 {% endif %}
 
-<article class="sec-text-img {{ bgklass }} {{ klass }} {{ include.sec.class }}">
+{% if include.sec.color %}
+  {% capture articleStyle %}color: {{ include.sec.color }};{% endcapture %}
+{% endif %}
+
+<article class="sec-text-img {{ bgklass }} {{ klass }} {{ include.sec.class }}" style="{{ articleStyle }}">
   {% if include.sec.bgcolor %}
     <span class="cs-article-background" style="background-color: {{ include.sec.bgcolor }}"></span>
   {% else %}

--- a/app/_layouts/base.html
+++ b/app/_layouts/base.html
@@ -14,11 +14,11 @@
 
   </head>
   {% if page.body_class %}
-  <body class="{{ page.body_class }}">
+  <body class="{{ page.body_class }} {{ page.theme }}">
   {% elsif layout.body_class %}
-  <body class="{{ layout.body_class }}">
+  <body class="{{ layout.body_class }} {{ page.theme }}">
   {% else %}
-  <body>
+  <body class="{{ page.theme }}">
   {% endif %}
     {% include header.html %}
     <main id="page-body" role="main">

--- a/app/_layouts/case-study.html
+++ b/app/_layouts/case-study.html
@@ -180,14 +180,14 @@ body_class: body-casestudy
     <a href="{{ site.baseurl }}{{ previous.url }}">
       <dl>
         <dt class="previous-project">Previous project</dt>
-        <dd><h3>{{ previous.title }}</h3></dd>
+        <dd><h3>{{ previous.client }}</h3></dd>
       </dl>
     </a>
 
     <a href="{{ site.baseurl }}{{ next.url }}">
       <dl>
         <dt class="next-project">Next project</dt>
-        <dd><h3>{{ next.title }}</h3></dd>
+        <dd><h3>{{ next.client }}</h3></dd>
       </dl>
     </a>
 

--- a/app/_layouts/case-study.html
+++ b/app/_layouts/case-study.html
@@ -86,10 +86,10 @@ body_class: body-casestudy
     {% endfor %}
   {% endif %}
 
-  {% if page.s_metrics %}
-  <article class="sec-metrics">
+  {% if page.s_metrics.items %}
+  <article class="sec-metrics {{ page.s_metrics.class }}">
     <ul class="row">
-      {% for metric in page.s_metrics %}
+      {% for metric in page.s_metrics.items %}
       <li>
         <dl>
           <dt class="container-invisible" data-animate="yellow">{{ metric.title }}</dt>

--- a/app/_layouts/case-study.html
+++ b/app/_layouts/case-study.html
@@ -147,44 +147,50 @@ body_class: body-casestudy
 
 <section class="cs-browse-more-projects">
   <div class="row browse-more-projects-wrap">
-    <a href="#">
+    {% comment %}
+      With this loop we get the item before and after the current if they exist.
+    {% endcomment %}
+
+    {% assign found = false %}
+    {% for case_study in site.case_studies %}
+      {% if case_study.url == page.url %}
+        {% assign found = true %}
+        {% continue %}
+      {% endif %}
+
+      {% if found %}
+        {% assign next = case_study %}
+        {% break %}
+      {% else %} 
+        {% assign previous = case_study %}
+      {% endif %}
+    {% endfor %}
+
+    {% comment %}
+      Assign the next and previous items if they were not found. It may happen
+      When we're dealing with the first and last entries in the array.
+    {% endcomment %}
+    {% unless next %}
+      {% assign next = site.case_studies | first %}
+    {% endunless %}
+    {% unless previous %}
+      {% assign previous = site.case_studies | last %}
+    {% endunless %}
+
+    <a href="{{ site.baseurl }}{{ previous.url }}">
       <dl>
         <dt class="previous-project">Previous project</dt>
-        <dd><h3>Wodify Arena</h3></dd>
+        <dd><h3>{{ previous.title }}</h3></dd>
       </dl>
     </a>
-    <a href="#">
+
+    <a href="{{ site.baseurl }}{{ next.url }}">
       <dl>
         <dt class="next-project">Next project</dt>
-        <dd><h3>Climatescope 2018</h3></dd>
+        <dd><h3>{{ next.title }}</h3></dd>
       </dl>
     </a>
 
     <!-- <h2 class="container-invisible" data-animate="yellow">Browse more projects</h2> -->
   </div>
-  <!-- <div class="browse-more-projects-wrap">
-    <ul>
-      {% comment %}
-        With these 2 loops we always print the list items that come after
-        the one being viewed and only after that we start from the beginning.
-      {% endcomment %}
-
-      {% assign found = false %}
-      {% for case_study in site.case_studies %}
-        {% if found %}
-          <li class="animatecontainer" data-animate="images">{% include case-studies/card.html case=case_study %}</li>
-        {% endif %}
-        {% if case_study.url == page.url %}
-          {% assign found = true %}
-        {% endif %}
-      {% endfor %}
-
-      {% for case_study in site.case_studies %}
-        {% if case_study.url == page.url %}
-          {% break %}
-        {% endif %}
-        <li>{% include case-studies/card.html case=case_study %}</li>
-      {% endfor %}
-    </ul>
-  </div> -->
 </section>

--- a/app/_layouts/case-study.html
+++ b/app/_layouts/case-study.html
@@ -2,7 +2,13 @@
 layout: base
 body_class: body-casestudy
 ---
-<section class="cs-hero">
+{% if page.hero.bg_image %}
+  {% capture style %}{{ style }}background-image: url('{{page.hero.bg_image}}');{% endcapture %}
+{% endif %}
+{% if page.hero.bg_color %}
+  {% capture style %}{{ style }}background-color: {{page.hero.bg_color}};{% endcapture %}
+{% endif %}
+<section class="cs-hero" style="{{ style }}">
   <div class="row">
     <figure>
       <img

--- a/app/assets/styles/partials/_casestudy.scss
+++ b/app/assets/styles/partials/_casestudy.scss
@@ -249,7 +249,6 @@ background-color: white;
 }
 
 .sec-background-custom{
-  color:white;
   .cs-article-background{
     width: 100%;
     height: 70%;

--- a/docs/content/case-studies.md
+++ b/docs/content/case-studies.md
@@ -15,6 +15,9 @@ theme:
 # Main section
 title:
 client:
+hero:
+  bg_color:
+  bg_image:
 images:
   full:
   small:
@@ -117,6 +120,9 @@ The `theme` variable allows a class to be added to the `body` tag. Leave empty f
 ```
 title:
 client:
+hero:
+  bg_color:
+  bg_image:
 images:
   full:
   small:
@@ -128,6 +134,8 @@ images:
 - `images.full` (string) is displayed on large screens
 - `images.small` (string) is displayed on small screens
 - `images.card` (string) is used for the cards on the "Other projects" section
+- `hero.bg_color` (string) color to be applied to the hero (applied to `section.cs-hero`)
+- `hero.bg_image` (string) image to be applied to the hero (applied to `section.cs-hero`)
 
 ### Intro section
 ![](sec-intro.jpg)

--- a/docs/content/case-studies.md
+++ b/docs/content/case-studies.md
@@ -44,9 +44,11 @@ s_summary:
 
 # Metrics section
 s_metrics:
-  - title:
-    description:
-    value:
+  class:
+  items:
+    - title:
+      description:
+      value:
 
 # Featured quote section
 s_feature_quote:
@@ -188,14 +190,17 @@ s_summary:
 All configuration for this section appears under the `s_metrics` key.
 ```
 s_metrics:
-  - title:
-    description:
-    value:
+  class:
+  items:
+    - title:
+      description:
+      value:
 ```
-- `[]` (array[objects]) list of metrics. Keep adding more items to the list if needed
-- `[].title` (string) metric title
-- `[].description` (string) metric description
-- `[].value` (string) metric value
+- `class` (string) If needed, an additional css class can be added to this section
+- `items[]` (array[objects]) list of metrics. Keep adding more items to the list if needed
+- `items[].title` (string) metric title
+- `items[].description` (string) metric description
+- `items[].value` (string) metric value
 
 ### Featured Quote section
 ![](sec-feat-quote.jpg)

--- a/docs/content/case-studies.md
+++ b/docs/content/case-studies.md
@@ -10,6 +10,7 @@ This is the base structure:
 ---
 layout: case-study
 permalink: case-studies/<slug>/
+theme:
 
 # Main section
 title:
@@ -105,9 +106,11 @@ Failing to do this will result in the variable being interpreted as plain text.
 ```
 layout: case-study
 permalink: case-studies/<slug>/
+theme:
 ```
 These variables are needed by jekyll.
 `layout` will always be `case-study` and the permalink should be unique (The trailing slash is important)
+The `theme` variable allows a class to be added to the `body` tag. Leave empty for no class.
 
 ### Main
 ![](sec-hero.jpg)

--- a/docs/content/case-studies.md
+++ b/docs/content/case-studies.md
@@ -71,6 +71,7 @@ s_content:
   - type:
     class:
     bgcolor:
+    color:
     title:
     content:
     images:
@@ -268,6 +269,7 @@ s_content:
         alt:
     bgcolor:
     class:
+    color:
 ```
 - `type` (string) type of the section as listed above
 - `title` (string) title of the section
@@ -277,6 +279,7 @@ s_content:
 - `image[].alt` (string) image tag alt text
 - `bgcolor` (string) background color for the section block. *Important*: This value must be between quotes
 - `class` (string) If needed, an additional css class can be added to this section
+- `color` (string) Text color for the section. Any css color is supported
 
 #### Image sections
 There are 2 types of image sections:


### PR DESCRIPTION
Este PR corrige várias issues relacionadas com os case studies:

#34 
Foi adicionada uma variável chamada `theme` que permite adicionar uma classe ao body. Qualquer valor passado será usado como classe. É mais flexível assim, mas também pode conduzir a erros. Vejam se preferem algo mais limitado.

#35
Podem agora usar as seguintes variáveis no case study:
```
hero:
  bg_color:
  bg_image:
```

Como os nomes indicam, permitem adicionar uma cor de fundo e uma imagem. São adicionados inline na `section.cs-hero`.

#37
Foi adicionada uma propriedade `color` às`s_content`. Qualquer cor que coloquem aqui será aplicada ao `article.sec-text-img`.

A cor branca está a ser aplicada através da classe `sec-background-custom`. Esta classe é adicionada sempre que existe uma cor de bg definida. Removi esta definição do css https://github.com/leihla/major/blob/bad501024b8d14127a4dd77895c4aa492c2ddb5c/app/assets/styles/partials/_casestudy.scss#L240

#38 
Implementado conforme a issue.

**Notas:**

1) Atualizei a documentação para refletir todas as alterações nas variáveis.

2) Aconselho que analisem a relação entre flexibilidade/resistência aos erros no que toca às variáveis de personalização. Permitir colocar uma cor custom / classes em cada secção permite grande poder de personalização, mas também pode resultar em erros e demasiadas cores a serem usadas.

Poderá ser mais benéfico ter, por exemplo, cores gerais por case study que são usadas em todo ele. Ou mesmo um conjunto finito de cores.

Uma opção não é mais correta que a outra. Escrevo isto só para estarem cientes do que pode acontecer.

cc @carloslopesalves @leihla 